### PR TITLE
Set project path to the NodeJSService 

### DIFF
--- a/BrunoLau.SpaServices/Common/NodeInteropFactory.cs
+++ b/BrunoLau.SpaServices/Common/NodeInteropFactory.cs
@@ -33,18 +33,24 @@ namespace BrunoLau.SpaServices.Common
         /// Builds new INodeJSService instance independent of the app services container
         /// </summary>
         /// <param name="environmentVariables"></param>
+        /// <param name="projectPath"></param>
         /// <returns></returns>
-        public static INodeJSService BuildNewInstance(IDictionary<string, string> environmentVariables)
+        public static INodeJSService BuildNewInstance(IDictionary<string, string> environmentVariables, string projectPath)
         {
             var services = new ServiceCollection();
             services.AddNodeJS();
-            ServiceProvider serviceProvider = services.BuildServiceProvider();
 
-            if (environmentVariables != null)
+            services.Configure<NodeJSProcessOptions>(options =>
             {
-                services.Configure<NodeJSProcessOptions>(options => options.EnvironmentVariables = environmentVariables);
-            }
+               if (environmentVariables != null)
+                  options.EnvironmentVariables = environmentVariables;
 
+               if (!string.IsNullOrWhiteSpace(projectPath))
+                  options.ProjectPath = projectPath;
+            });
+
+         
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
             return serviceProvider.GetRequiredService<INodeJSService>();
         }
 

--- a/BrunoLau.SpaServices/Webpack/WebpackDevMiddleware.cs
+++ b/BrunoLau.SpaServices/Webpack/WebpackDevMiddleware.cs
@@ -93,7 +93,7 @@ namespace BrunoLau.SpaServices.Webpack
             // middleware). And since this is a dev-time-only feature, it doesn't matter if the default transport isn't
             // as fast as some theoretical future alternative.
             // This should do it by using Jering.Javascript.NodeJS interop
-            var nodeJSService = NodeInteropFactory.BuildNewInstance(environmentVariables);
+            var nodeJSService = NodeInteropFactory.BuildNewInstance(environmentVariables, options.ProjectPath);
 
 
             // Ideally, this would be relative to the application's PathBase (so it could work in virtual directories)


### PR DESCRIPTION
Thanks for this project!  I submitted this PR to fix issue #1: when node_modules is not placed in the root path, the webpack-dev-middleware script will fail to load aspnet-webpack.   The solution is to pass the ProjectPath option to the NodeJSService, and also make sure the options are set by configuring the options before the service provider is built.
